### PR TITLE
SPARK-25 | Refactor Declaration Type

### DIFF
--- a/Sources/SparkleCSS/Declaration.swift
+++ b/Sources/SparkleCSS/Declaration.swift
@@ -21,26 +21,8 @@ public struct Declaration {
     self.property = property
     self.value = value.render()
   }
-
-  /// Creates a CSS declaration with multiple values.
-  /// - Parameters:
-  ///   - property: The name of the CSS property.
-  ///   - values: The values in the declaration.
-  public init<V: Value>(property: String, values: [V]) {
-    self.property = property
-    self.value = values.render()
-  }
 }
 
 // MARK: - Equatable
 
 extension Declaration: Equatable {}
-
-extension Collection where Element: Renderable {
-  public func render() -> String {
-    map {
-      $0.render()
-    }
-    .joined(separator: " ")
-  }
-}

--- a/Sources/SparkleCSS/Declarations/Margin+Declaration.swift
+++ b/Sources/SparkleCSS/Declarations/Margin+Declaration.swift
@@ -8,36 +8,6 @@ extension Declaration {
 
   /// Creates a declaration to set the margins of a component.
   /// - Parameters:
-  ///   - vertical: The value of the vertical margins.
-  ///   - horizontal: The value of the horizontal margins.
-  /// - Returns: The declaration that sets the margins.
-  public static func margin(vertical: Unit, horizontal: Unit) -> Declaration {
-    Declaration(property: "margin", values: [vertical, horizontal])
-  }
-
-  /// Creates a declaration to set the margins of a component.
-  /// - Parameters:
-  ///   - top: The value of the top margin.
-  ///   - horizontal: The value of the horizontal margins.
-  ///   - bottom: The value of the bottom margin.
-  /// - Returns: The declaration that sets the margins.
-  public static func margin(top: Unit, horizontal: Unit, bottom: Unit) -> Declaration {
-    Declaration(property: "margin", values: [top, horizontal, bottom])
-  }
-
-  /// Creates a declaration to set the margins of a component.
-  /// - Parameters:
-  ///   - top: The value of the top margin.
-  ///   - right: The value of the right margin.
-  ///   - bottom: The value of the bottom margin.
-  ///   - left: The value of the left margin.
-  /// - Returns: The declaration that sets the margins.
-  public static func margin(top: Unit, right: Unit, bottom: Unit, left: Unit) -> Declaration {
-    Declaration(property: "margin", values: [top, right, bottom, left])
-  }
-
-  /// Creates a declaration to set the margins of a component.
-  /// - Parameters:
   ///   - edge: The edge where the margin should be applied.
   ///   - value: The value of the margin to apply.
   /// - Returns: The declaration that sets the margins.

--- a/Sources/SparkleCSS/Declarations/Padding+Declaration.swift
+++ b/Sources/SparkleCSS/Declarations/Padding+Declaration.swift
@@ -8,36 +8,6 @@ extension Declaration {
 
   /// Creates a declaration to set the padding of a component.
   /// - Parameters:
-  ///   - vertical: The value of the vertical padding.
-  ///   - horizontal: The value of the horizontal padding.
-  /// - Returns: The declaration that sets the padding.
-  public static func padding(vertical: Unit, horizontal: Unit) -> Declaration {
-    Declaration(property: "padding", values: [vertical, horizontal])
-  }
-
-  /// Creates a declaration to set the padding of a component.
-  /// - Parameters:
-  ///   - top: The value of the top padding.
-  ///   - horizontal: The value of the horizontal padding.
-  ///   - bottom: The value of the bottom padding.
-  /// - Returns: The declaration that sets the padding.
-  public static func padding(top: Unit, horizontal: Unit, bottom: Unit) -> Declaration {
-    Declaration(property: "padding", values: [top, horizontal, bottom])
-  }
-
-  /// Creates a declaration to set the padding of a component.
-  /// - Parameters:
-  ///   - top: The value of the top padding.
-  ///   - right: The value of the right padding.
-  ///   - bottom: The value of the bottom padding.
-  ///   - left: The value of the left padding.
-  /// - Returns: The declaration that sets the padding.
-  public static func padding(top: Unit, right: Unit, bottom: Unit, left: Unit) -> Declaration {
-    Declaration(property: "padding", values: [top, right, bottom, left])
-  }
-
-  /// Creates a declaration to set the padding of a component.
-  /// - Parameters:
   ///   - edge: The edge where the padding should be applied.
   ///   - value: The value of the padding to apply.
   /// - Returns: The declaration that sets the padding.

--- a/Sources/SparkleCSS/Rules/Margin+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Margin+Rule.swift
@@ -11,45 +11,6 @@ extension Rule {
 
   /// Creates a rule that sets the margins of a component.
   /// - Parameters:
-  ///   - vertical: The value of the vertical margins.
-  ///   - horizontal: The value of the horizontal margins.
-  /// - Returns: The rule for a class that sets the margins.
-  public static func margin(vertical: Unit, horizontal: Unit) -> Rule {
-    Rule(
-      .class("margin-v-\(vertical.render())-h-\(horizontal.render())"),
-      declarations: .margin(vertical: vertical, horizontal: horizontal)
-    )
-  }
-
-  /// Creates a rule that sets the margins of a component.
-  /// - Parameters:
-  ///   - top: The value of the top margins.
-  ///   - horizontal: The value of the horizontal margins.
-  ///   - bottom: The value of the bottom margins.
-  /// - Returns: The rule for a class that sets the margins.
-  public static func margin(top: Unit, horizontal: Unit, bottom: Unit) -> Rule {
-    Rule(
-      .class("margin-t-\(top.render())-h-\(horizontal)-b-\(bottom)"),
-      declarations: .margin(top: top, horizontal: horizontal, bottom: bottom)
-    )
-  }
-
-  /// Creates a rule that sets the margins of a component.
-  /// - Parameters:
-  ///   - top: The value of the top margins.
-  ///   - right: The value of the right margins.
-  ///   - bottom: The value of the bottom margins.
-  ///   - left: The value of the left margins.
-  /// - Returns: The rule for a class that sets the margins.
-  public static func margin(top: Unit, right: Unit, bottom: Unit, left: Unit) -> Rule {
-    Rule(
-      .class("margin-t-\(top.render())-r-\(right.render())-b-\(bottom.render())-l-\(left)"),
-      declarations: .margin(top: top, right: right, bottom: bottom, left: left)
-    )
-  }
-
-  /// Creates a rule that sets the margins of a component.
-  /// - Parameters:
   ///   - edge: The edge where the margin should be applied.
   ///   - value: The value of the margin to apply.
   /// - Returns: The rule for a class that sets the margins.

--- a/Sources/SparkleCSS/Rules/Padding+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Padding+Rule.swift
@@ -11,32 +11,6 @@ extension Rule {
 
   /// Creates a rule that sets the padding of a component.
   /// - Parameters:
-  ///   - vertical: The value of the vertical padding.
-  ///   - horizontal: The value of the horizontal padding.
-  /// - Returns: The rule for a class that sets the padding.
-  public static func padding(vertical: Unit, horizontal: Unit) -> Rule {
-    Rule(
-      .class("padding-v-\(vertical.render())-h-\(horizontal.render())"),
-      declarations: .padding(vertical: vertical, horizontal: horizontal)
-    )
-  }
-
-  /// Creates a rule that sets the padding of a component.
-  /// - Parameters:
-  ///   - top: The value of the top padding.
-  ///   - right: The value of the right padding.
-  ///   - bottom: The value of the bottom padding.
-  ///   - left: The value of the left padding.
-  /// - Returns: The rule for a class that sets the padding.
-  public static func padding(top: Unit, right: Unit, bottom: Unit, left: Unit) -> Rule {
-    Rule(
-      .class("padding-t-\(top.render())-r-\(right.render())-b-\(bottom.render())-l-\(left)"),
-      declarations: .padding(top: top, right: right, bottom: bottom, left: left)
-    )
-  }
-
-  /// Creates a rule that sets the padding of a component.
-  /// - Parameters:
   ///   - edge: The edge where the padding should be applied.
   ///   - value: The value of the padding to apply.
   /// - Returns: The rule for a class that sets the padding.

--- a/Tests/SparkleCSSTests/DeclarationTests.swift
+++ b/Tests/SparkleCSSTests/DeclarationTests.swift
@@ -17,20 +17,6 @@ final class DeclarationTests: XCTestCase {
     XCTAssertEqual(renderer.render(sut), expectedResult)
   }
 
-  func testMarginAllEdgesDeclaration() {
-    let sut = Declaration.margin(top: .pixel(4), right: .pixel(8), bottom: .pixel(4), left: .pixel(8))
-    let expectedResult = "margin: 4px 8px 4px 8px;"
-
-    XCTAssertEqual(renderer.render(sut), expectedResult)
-  }
-
-  func testMarginAxisDeclaration() {
-    let sut = Declaration.margin(vertical: .pixel(4), horizontal: .pixel(8))
-    let expectedResult = "margin: 4px 8px;"
-
-    XCTAssertEqual(renderer.render(sut), expectedResult)
-  }
-
   func testMarginEdgeDeclaration() {
     let sut = Declaration.margin(.top, .pixel(4))
     let expectedResult = "margin-top: 4px;"


### PR DESCRIPTION
## Removed
- The `Declaration` initializer that allowed an array of values has been removed since it's not always possible to predict how these values should be rendered in CSS. Instead, use a wrapper value type to represent values such as margins on all edges with different values (`margin: 8px 4px 2px 12px;`).
- Rules and declarations that allowed margins and padding to be set on different edges simultaneously.