### PR TITLE
SPARK-22 | Improve Edge, Padding and Margin

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Sparkle.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Sparkle.xcscheme
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Sparkle"
+               BuildableName = "Sparkle"
+               BlueprintName = "Sparkle"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleCSSTests"
+               BuildableName = "SparkleCSSTests"
+               BlueprintName = "SparkleCSSTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleHTMLTests"
+               BuildableName = "SparkleHTMLTests"
+               BlueprintName = "SparkleHTMLTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleTests"
+               BuildableName = "SparkleTests"
+               BlueprintName = "SparkleTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleCSS"
+               BuildableName = "SparkleCSS"
+               BlueprintName = "SparkleCSS"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleHTML"
+               BuildableName = "SparkleHTML"
+               BlueprintName = "SparkleHTML"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleTools"
+               BuildableName = "SparkleTools"
+               BlueprintName = "SparkleTools"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleCSSTests"
+               BuildableName = "SparkleCSSTests"
+               BlueprintName = "SparkleCSSTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleHTMLTests"
+               BuildableName = "SparkleHTMLTests"
+               BlueprintName = "SparkleHTMLTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SparkleTests"
+               BuildableName = "SparkleTests"
+               BlueprintName = "SparkleTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Sparkle"
+            BuildableName = "Sparkle"
+            BlueprintName = "Sparkle"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/SparkleCSS/Edge.swift
+++ b/Sources/SparkleCSS/Edge.swift
@@ -12,3 +12,87 @@ public enum Edge: String {
   /// The right edge.
   case right
 }
+
+extension Edge {
+  /// A set of `Edge`s.
+  public struct Set: OptionSet {
+    /// A set that contains all edges.
+    public static let all: Edge.Set = [.top, .left, .bottom, .right]
+
+    /// A set that contains edges on the horizontal axis.
+    public static let horizontal: Edge.Set = [.left, .right]
+
+    /// A set that contains edges on the vertical axis.
+    public static let vertical: Edge.Set = [.top, .bottom]
+
+    /// The top edge.
+    public static let top = Edge.Set(rawValue: 1 << 0)
+
+    /// The left edge.
+    public static let left = Edge.Set(rawValue: 1 << 1)
+
+    /// The bottom edge.
+    public static let bottom = Edge.Set(rawValue: 1 << 2)
+
+    /// The right edge.
+    public static let right = Edge.Set(rawValue: 1 << 3)
+
+    public let rawValue: UInt8
+
+    /// The name of the `Edge` set.
+    var name: String {
+      switch self {
+        case .top:
+          return "top"
+
+        case .left:
+          return "left"
+
+        case .right:
+          return "right"
+
+        case .bottom:
+          return "bottom"
+
+        case .horizontal:
+          return "horizontal"
+
+        case .vertical:
+          return "vertical"
+
+        case .all:
+          return ""
+
+        default:
+          return ""
+      }
+    }
+
+    /// The list of `Edge`s contained in the set.
+    var edges: [Edge] {
+      var edges: [Edge] = []
+
+      if contains(.top) {
+        edges.append(.top)
+      }
+
+      if contains(.left) {
+        edges.append(.left)
+      }
+
+      if contains(.right) {
+        edges.append(.right)
+      }
+
+      if contains(.bottom) {
+        edges.append(.bottom)
+      }
+
+      return edges
+    }
+
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+  }
+}

--- a/Sources/SparkleCSS/Edge.swift
+++ b/Sources/SparkleCSS/Edge.swift
@@ -64,7 +64,9 @@ extension Edge {
           return ""
 
         default:
-          return ""
+          return edges
+            .map(\.rawValue)
+            .joined(separator: "-")
       }
     }
 

--- a/Sources/SparkleCSS/Rule.swift
+++ b/Sources/SparkleCSS/Rule.swift
@@ -50,8 +50,17 @@ public struct Rule {
   /// Creates a new rule by specifying the name of the CSS class and a declaration.
   /// - Parameters:
   ///   - name: The name of the CSS class.
-  ///   - declaration: The list of CSS declarations that set a styles.
+  ///   - declarations: The list of CSS declarations that set a styles.
   public init(_ selector: Selector, declarations: Declaration...) {
+    self.selector = selector
+    self.declarations = declarations
+  }
+
+  /// Creates a new rule by specifying the name of the CSS class and a declaration.
+  /// - Parameters:
+  ///   - name: The name of the CSS class.
+  ///   - declarations: The list of CSS declarations that set a styles.
+  public init(_ selector: Selector, declarations: [Declaration]) {
     self.selector = selector
     self.declarations = declarations
   }

--- a/Sources/SparkleCSS/Rule.swift
+++ b/Sources/SparkleCSS/Rule.swift
@@ -50,7 +50,7 @@ public struct Rule {
   /// Creates a new rule by specifying the name of the CSS class and a declaration.
   /// - Parameters:
   ///   - name: The name of the CSS class.
-  ///   - declarations: The list of CSS declarations that set a styles.
+  ///   - declarations: The list of CSS declarations that set a style.
   public init(_ selector: Selector, declarations: Declaration...) {
     self.selector = selector
     self.declarations = declarations
@@ -59,7 +59,7 @@ public struct Rule {
   /// Creates a new rule by specifying the name of the CSS class and a declaration.
   /// - Parameters:
   ///   - name: The name of the CSS class.
-  ///   - declarations: The list of CSS declarations that set a styles.
+  ///   - declarations: The list of CSS declarations that set a style.
   public init(_ selector: Selector, declarations: [Declaration]) {
     self.selector = selector
     self.declarations = declarations

--- a/Sources/SparkleCSS/Rules/Margin+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Margin+Rule.swift
@@ -30,12 +30,8 @@ extension Rule {
         )
 
       default:
-        let className = edge.edges
-          .map(\.rawValue)
-          .joined(separator: "-")
-
         return Rule(
-          .class("margin-\(className)-\(value.render())"),
+          .class("margin-\(edge.name)-\(value.render())"),
           declarations: declarations
         )
     }

--- a/Sources/SparkleCSS/Rules/Margin+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Margin+Rule.swift
@@ -3,10 +3,7 @@ extension Rule {
   /// - Parameter value: The value of the margin on all edges.
   /// - Returns: The rule for a class that sets the margins.
   public static func margin(_ value: Unit) -> Rule {
-    Rule(
-      .class("margin-\(value.render())"),
-      declarations: .margin(value)
-    )
+    margin(.all, value)
   }
 
   /// Creates a rule that sets the margins of a component.
@@ -14,10 +11,33 @@ extension Rule {
   ///   - edge: The edge where the margin should be applied.
   ///   - value: The value of the margin to apply.
   /// - Returns: The rule for a class that sets the margins.
-  public static func margin(_ edge: Edge, _ value: Unit) -> Rule {
-    Rule(
-      .class("margin-\(edge.rawValue)-\(value.render())"),
-      declarations: .margin(edge, value)
-    )
+  public static func margin(_ edge: Edge.Set, _ value: Unit) -> Rule {
+    let declarations: [Declaration] = edge.edges.map { edge in
+        .margin(edge, value)
+    }
+
+    switch edge {
+      case .all:
+        return Rule(
+          .class("margin-\(value.render())"),
+          declarations: .margin(value)
+        )
+
+      case .horizontal, .vertical, .top, .left, .right, .bottom:
+        return Rule(
+          .class("margin-\(edge.name)-\(value.render())"),
+          declarations: declarations
+        )
+
+      default:
+        let className = edge.edges
+          .map(\.rawValue)
+          .joined(separator: "-")
+
+        return Rule(
+          .class("margin-\(className)-\(value.render())"),
+          declarations: declarations
+        )
+    }
   }
 }

--- a/Sources/SparkleCSS/Rules/Padding+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Padding+Rule.swift
@@ -30,12 +30,8 @@ extension Rule {
         )
 
       default:
-        let className = edge.edges
-          .map(\.rawValue)
-          .joined(separator: "-")
-
         return Rule(
-          .class("padding-\(className)-\(value.render())"),
+          .class("padding-\(edge.name)-\(value.render())"),
           declarations: declarations
         )
     }

--- a/Sources/SparkleCSS/Rules/Padding+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Padding+Rule.swift
@@ -1,12 +1,9 @@
 extension Rule {
-  /// Creates a rule that sets the padding of a component.
-  /// - Parameter value: The value of the padding on all edges.
+  /// Creates a rule that sets the padding on all edges of a component.
+  /// - Parameter value: The value of the padding to apply.
   /// - Returns: The rule for a class that sets the padding.
   public static func padding(_ value: Unit) -> Rule {
-    Rule(
-      .class("padding-\(value.render())"),
-      declarations: .padding(value)
-    )
+    padding(.all, value)
   }
 
   /// Creates a rule that sets the padding of a component.
@@ -14,10 +11,33 @@ extension Rule {
   ///   - edge: The edge where the padding should be applied.
   ///   - value: The value of the padding to apply.
   /// - Returns: The rule for a class that sets the padding.
-  public static func padding(_ edge: Edge, _ value: Unit) -> Rule {
-    Rule(
-      .class("padding-\(edge.rawValue)-\(value.render())"),
-      declarations: .padding(edge, value)
-    )
+  public static func padding(_ edge: Edge.Set, _ value: Unit) -> Rule {
+    let declarations: [Declaration] = edge.edges.map { edge in
+        .padding(edge, value)
+    }
+
+    switch edge {
+      case .all:
+        return Rule(
+          .class("padding-\(value.render())"),
+          declarations: .padding(value)
+        )
+
+      case .horizontal, .vertical, .top, .left, .right, .bottom:
+        return Rule(
+          .class("padding-\(edge.name)-\(value.render())"),
+          declarations: declarations
+        )
+
+      default:
+        let className = edge.edges
+          .map(\.rawValue)
+          .joined(separator: "-")
+
+        return Rule(
+          .class("padding-\(className)-\(value.render())"),
+          declarations: declarations
+        )
+    }
   }
 }

--- a/Sources/SparkleHTML/Modifiers/Margin+Modifiers.swift
+++ b/Sources/SparkleHTML/Modifiers/Margin+Modifiers.swift
@@ -13,7 +13,7 @@ extension Component {
   ///   - edge: The edge on which to apply the margin.
   ///   - value: The value of the margin.
   /// - Returns: The component updated with the newly generated margin class.
-  public func margin(_ edge: Edge, _ value: Unit) -> Component {
+  public func margin(_ edge: Edge.Set = .all, _ value: Unit) -> Component {
     rule(.margin(edge, value))
   }
 }

--- a/Sources/SparkleHTML/Modifiers/Padding+Modifiers.swift
+++ b/Sources/SparkleHTML/Modifiers/Padding+Modifiers.swift
@@ -13,7 +13,7 @@ extension Component {
   ///   - edge: The edge on which to apply the padding.
   ///   - value: The value of the padding.
   /// - Returns: The component updated with the newly generated padding class.
-  public func padding(_ edge: Edge, _ value: Unit) -> Component {
+  public func padding(_ edge: Edge.Set = .all, _ value: Unit) -> Component {
     rule(.padding(edge, value))
   }
 }

--- a/Tests/SparkleCSSTests/EdgeTests.swift
+++ b/Tests/SparkleCSSTests/EdgeTests.swift
@@ -1,10 +1,3 @@
-//
-//  EdgeTests.swift
-//  
-//
-//  Created by Gaetano Matonti on 11/11/22.
-//
-
 import XCTest
 @testable import SparkleCSS
 

--- a/Tests/SparkleCSSTests/EdgeTests.swift
+++ b/Tests/SparkleCSSTests/EdgeTests.swift
@@ -1,0 +1,34 @@
+//
+//  EdgeTests.swift
+//  
+//
+//  Created by Gaetano Matonti on 11/11/22.
+//
+
+import XCTest
+@testable import SparkleCSS
+
+final class EdgeTests: XCTestCase {
+  func testAllEdgeSet() {
+    let sut = Edge.Set.all
+
+    XCTAssertTrue(sut.contains(.top))
+    XCTAssertTrue(sut.contains(.left))
+    XCTAssertTrue(sut.contains(.right))
+    XCTAssertTrue(sut.contains(.bottom))
+  }
+
+  func testHorizontalEdgeSet() {
+    let sut = Edge.Set.horizontal
+
+    XCTAssertTrue(sut.contains(.left))
+    XCTAssertTrue(sut.contains(.right))
+  }
+
+  func testVerticalEdgeSet() {
+    let sut = Edge.Set.vertical
+
+    XCTAssertTrue(sut.contains(.top))
+    XCTAssertTrue(sut.contains(.bottom))
+  }
+}

--- a/Tests/SparkleCSSTests/MarginTests.swift
+++ b/Tests/SparkleCSSTests/MarginTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import SparkleTools
+@testable import SparkleCSS
+
+final class MarginTests: XCTestCase {
+  var renderer: StyleSheetRenderer.RuleRenderer!
+
+  override func setUp() {
+    renderer = StyleSheetRenderer.RuleRenderer(indentation: Indentation(kind: .spaces(2), allowsNewlines: true))
+  }
+
+  func testMarginSingleEdgeRule() {
+    let sut = Rule.margin(.left, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .margin-left-1rem {
+        margin-left: 1rem;
+      }
+      """
+    )
+  }
+
+  func testMarginHorizontalEdgesRule() {
+    let sut = Rule.margin(.horizontal, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .margin-horizontal-1rem {
+        margin-left: 1rem;
+        margin-right: 1rem;
+      }
+      """
+    )
+  }
+
+  func testMarginVerticalEdgesRule() {
+    let sut = Rule.margin(.vertical, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .margin-vertical-1rem {
+        margin-top: 1rem;
+        margin-bottom: 1rem;
+      }
+      """
+      )
+  }
+
+  func testMarginAllEdgesRule() {
+    let sut = Rule.margin(.rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .margin-1rem {
+        margin: 1rem;
+      }
+      """
+    )
+  }
+}

--- a/Tests/SparkleCSSTests/PaddingTests.swift
+++ b/Tests/SparkleCSSTests/PaddingTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import SparkleTools
+@testable import SparkleCSS
+
+final class PaddingTests: XCTestCase {
+  var renderer: StyleSheetRenderer.RuleRenderer!
+
+  override func setUp() {
+    renderer = StyleSheetRenderer.RuleRenderer(indentation: Indentation(kind: .spaces(2), allowsNewlines: true))
+  }
+
+  func testPaddingSingleEdgeRule() {
+    let sut = Rule.padding(.left, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .padding-left-1rem {
+        padding-left: 1rem;
+      }
+      """
+    )
+  }
+
+  func testPaddingHorizontalEdgesRule() {
+    let sut = Rule.padding(.horizontal, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .padding-horizontal-1rem {
+        padding-left: 1rem;
+        padding-right: 1rem;
+      }
+      """
+    )
+  }
+
+  func testPaddingVerticalEdgesRule() {
+    let sut = Rule.padding(.vertical, .rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .padding-vertical-1rem {
+        padding-top: 1rem;
+        padding-bottom: 1rem;
+      }
+      """
+      )
+  }
+
+  func testPaddingAllEdgesRule() {
+    let sut = Rule.padding(.rem(1))
+
+    XCTAssertEqual(
+      renderer.render(sut),
+      """
+      .padding-1rem {
+        padding: 1rem;
+      }
+      """
+    )
+  }
+}


### PR DESCRIPTION
### Improved
- The `Edge` model now as a `Set` which convienently gives premade sets, such as `all`, `horizontal` and `vertical`
- Both the padding and margin modifiers have been improved to support the new `Edge.Set`
- The `Edge` and padding and margin modifier methods are now tested

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)