### PR TITLE
SPARK-29 | Fix Sparkle not Building on Linux

### DIFF
--- a/Sources/SparkleCSS/Colors/Hex.swift
+++ b/Sources/SparkleCSS/Colors/Hex.swift
@@ -1,8 +1,6 @@
-#if canImport(RegexBuilder)
-import RegexBuilder
+import Foundation
 
 /// A color expressed in its hexadecimal value.
-@available(macOS 13.0, *)
 public struct Hex: ExpressibleByStringLiteral, Color, BackgroundStyle, ForegroundStyle {
 
   /// The value of the color.
@@ -17,50 +15,14 @@ public struct Hex: ExpressibleByStringLiteral, Color, BackgroundStyle, Foregroun
   /// Creates a color from its `String` hexadecimal representation.
   /// - Parameter hex: The hexadecimal representation of the color.
   public init(_ hex: String) {
-    let regex = Regex {
-      Optionally("#")
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      Optionally {
-        TryCapture {
-          Repeat(.hexDigit, count: 2)
-        } transform: {
-          String($0)
-        }
-      }
-    }
-
-    guard let (_, red, green, blue, alpha) = hex.wholeMatch(of: regex)?.output else {
-      value = "000000"
-      return
-    }
-
-    value = red + green + blue + (alpha ?? "")
+    value = hex
   }
 
   public var className: String {
-    "hex" + value
+    "hex-" + value
   }
 
   public func render() -> String {
     "#" + value
   }
 }
-#endif

--- a/Tests/SparkleCSSTests/ColorTests.swift
+++ b/Tests/SparkleCSSTests/ColorTests.swift
@@ -23,15 +23,6 @@ final class ColorTests: XCTestCase {
   }
 
   func testHexRegex() throws {
-    guard #available(macOS 13.0, *) else {
-      XCTAssertTrue(true)
-      return
-    }
-
-    #if canImport(RegexBuilder)
-    let sut = "#FFFFFF"
-
-    XCTAssertEqual(Hex(sut).value, "FFFFFF")
-    #endif
+    XCTAssertEqual(Hex("FFFFFF").value, "FFFFFF")
   }
 }


### PR DESCRIPTION
## Fixed
- Fixed builds failing on Linux environments.

## Removed
- Syntax checking for `Hex` values has been removed.