### PR TITLE
SPARKLE-30 | Fix Crash when Inserting Multiple Rules

### DIFF
--- a/Sources/SparkleCSS/Renderer/Renderer.swift
+++ b/Sources/SparkleCSS/Renderer/Renderer.swift
@@ -57,6 +57,12 @@ public final class StyleSheetRenderer {
     rules.insert(rule)
   }
 
+  /// Inserts a lit of rules in the set of rules to render.
+  /// - Parameter rules: The list of rules to add to the set of rules.
+  public func insert(_ rules: [Rule]) {
+    self.rules.formUnion(rules)
+  }
+
   /// Renders the rules in `String` format, sorted alphabetically.
   public func render() -> String {
     let imports = imports

--- a/Tests/SparkleCSSTests/StylesheetRendererTests.swift
+++ b/Tests/SparkleCSSTests/StylesheetRendererTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SparkleTools
+@testable import SparkleCSS
+
+final class StylesheetRendererTests: XCTestCase {
+
+  var renderer: StyleSheetRenderer!
+
+  override func setUp() {
+    renderer = StyleSheetRenderer(indentation: Indentation(kind: .spaces(2), allowsNewlines: true))
+  }
+
+  func testInsertMultipleRules() {
+    renderer.insert(.textAlignment(.center))
+
+    renderer.insert([
+      .textAlignment(.center),
+      .margin(.horizontal, .auto)
+    ])
+
+    XCTAssertEqual(renderer.rules.count, 2)
+    XCTAssertTrue(renderer.rules.contains(.textAlignment(.center)))
+    XCTAssertTrue(renderer.rules.contains(.margin(.horizontal, .auto)))
+  }
+}


### PR DESCRIPTION
## Added
- A new `insert(_ rules:)` method has been added to add multiple rules at once.

## Fixed
- A crash that would occur when trying to insert rules by calling the `insert(_ rule:)` method multiple times, for example in a `for` loop.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)