### PR TITLE
Release 0.3.1

### DIFF
--- a/Sources/SparkleCSS/Colors/Hex.swift
+++ b/Sources/SparkleCSS/Colors/Hex.swift
@@ -1,8 +1,6 @@
-#if canImport(RegexBuilder)
-import RegexBuilder
+import Foundation
 
 /// A color expressed in its hexadecimal value.
-@available(macOS 13.0, *)
 public struct Hex: ExpressibleByStringLiteral, Color, BackgroundStyle, ForegroundStyle {
 
   /// The value of the color.
@@ -17,50 +15,14 @@ public struct Hex: ExpressibleByStringLiteral, Color, BackgroundStyle, Foregroun
   /// Creates a color from its `String` hexadecimal representation.
   /// - Parameter hex: The hexadecimal representation of the color.
   public init(_ hex: String) {
-    let regex = Regex {
-      Optionally("#")
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      TryCapture {
-        Repeat(.hexDigit, count: 2)
-      } transform: {
-        String($0)
-      }
-
-      Optionally {
-        TryCapture {
-          Repeat(.hexDigit, count: 2)
-        } transform: {
-          String($0)
-        }
-      }
-    }
-
-    guard let (_, red, green, blue, alpha) = hex.wholeMatch(of: regex)?.output else {
-      value = "000000"
-      return
-    }
-
-    value = red + green + blue + (alpha ?? "")
+    value = hex
   }
 
   public var className: String {
-    "hex" + value
+    "hex-" + value
   }
 
   public func render() -> String {
     "#" + value
   }
 }
-#endif

--- a/Sources/SparkleCSS/Renderer/Renderer.swift
+++ b/Sources/SparkleCSS/Renderer/Renderer.swift
@@ -57,6 +57,12 @@ public final class StyleSheetRenderer {
     rules.insert(rule)
   }
 
+  /// Inserts a lit of rules in the set of rules to render.
+  /// - Parameter rules: The list of rules to add to the set of rules.
+  public func insert(_ rules: [Rule]) {
+    self.rules.formUnion(rules)
+  }
+
   /// Renders the rules in `String` format, sorted alphabetically.
   public func render() -> String {
     let imports = imports

--- a/Tests/SparkleCSSTests/ColorTests.swift
+++ b/Tests/SparkleCSSTests/ColorTests.swift
@@ -23,15 +23,6 @@ final class ColorTests: XCTestCase {
   }
 
   func testHexRegex() throws {
-    guard #available(macOS 13.0, *) else {
-      XCTAssertTrue(true)
-      return
-    }
-
-    #if canImport(RegexBuilder)
-    let sut = "#FFFFFF"
-
-    XCTAssertEqual(Hex(sut).value, "FFFFFF")
-    #endif
+    XCTAssertEqual(Hex("FFFFFF").value, "FFFFFF")
   }
 }

--- a/Tests/SparkleCSSTests/StylesheetRendererTests.swift
+++ b/Tests/SparkleCSSTests/StylesheetRendererTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SparkleTools
+@testable import SparkleCSS
+
+final class StylesheetRendererTests: XCTestCase {
+
+  var renderer: StyleSheetRenderer!
+
+  override func setUp() {
+    renderer = StyleSheetRenderer(indentation: Indentation(kind: .spaces(2), allowsNewlines: true))
+  }
+
+  func testInsertMultipleRules() {
+    renderer.insert(.textAlignment(.center))
+
+    renderer.insert([
+      .textAlignment(.center),
+      .margin(.horizontal, .auto)
+    ])
+
+    XCTAssertEqual(renderer.rules.count, 2)
+    XCTAssertTrue(renderer.rules.contains(.textAlignment(.center)))
+    XCTAssertTrue(renderer.rules.contains(.margin(.horizontal, .auto)))
+  }
+}


### PR DESCRIPTION
## Added
- A new `insert(_ rules:)` method has been added to add multiple rules at once.

## Fixed
- A crash that would occur when trying to insert rules by calling the `insert(_ rule:)` method multiple times, for example in a `for` loop.
- Fixed builds failing on Linux environments.

## Removed
- Syntax checking for `Hex` values has been removed.