### PR TITLE
SPARK-32 | Fix Height Rule Incorrect Declaration

### DIFF
--- a/Sources/SparkleCSS/Rules/Dimensions+Rule.swift
+++ b/Sources/SparkleCSS/Rules/Dimensions+Rule.swift
@@ -45,7 +45,7 @@ extension Rule {
   public static func height<V>(_ value: V) -> Rule where V: MeasurementValue {
     Rule(
       .class("height-\(value.className)"),
-      declarations: .width(value)
+      declarations: .height(value)
     )
   }
 


### PR DESCRIPTION
This PR fixes the incorrect declaration inside the method the applies the height rule.