### PR TITLE
Release 0.4.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,10 @@ let package = Package(
       dependencies: ["SparkleCSS", "SparkleHTML", "SparkleTools"]
     ),
     .testTarget(
+      name: "SparkleTests",
+      dependencies: ["Sparkle"]
+    ),
+    .testTarget(
       name: "SparkleCSSTests",
       dependencies: ["SparkleCSS"]
     ),

--- a/Sources/Sparkle/Site.swift
+++ b/Sources/Sparkle/Site.swift
@@ -18,21 +18,19 @@ public protocol Site {
   var additionalPages: [Page] { get }
 }
 
-public extension Site {
-  var baseURL: URL {
+extension Site {
+  public var baseURL: URL {
     URL(string: "https://example.org")!
   }
 
-  var locale: Locale {
+  public var locale: Locale {
     Locale(identifier: "en_US")
   }
 
-  var additionalPages: [Page] {
+  public var additionalPages: [Page] {
     []
   }
-}
 
-extension Site {
   /// The `URL` of the directory where all generated files should be saved.
   private var outputPath: URL {
     let filePath = URL(fileURLWithPath: #file.description)
@@ -46,30 +44,34 @@ extension Site {
   ///
   /// Use this method to add pre-existent or custom rules to be rendered into your stylesheet.
   /// - Parameter configure: A closure that allows to configure the `RulesContainer` instance in the environment.
-  public func configureStyleSheet(_ configure: (RulesContainer) -> Void) {
-    configure(EnvironmentValues.rulesContainer)
+  public func configureStyleSheet(_ configure: @escaping (RulesContainer) async -> Void) {
+    Task {
+      await configure(EnvironmentValues.rulesContainer)
+    }
   }
 
   /// Generates the site at the default `Output` directory of the package.
   /// - Parameter indentation: The indentation to use when rendering code in the HTML and CSS files.
-  public func generate(with indentation: Indentation = Indentation(), _ file: StaticString = #file) throws {
-    try generateHTML(with: indentation)
-    try generateCSS(with: indentation)
+  public func generate(with indentation: Indentation = Indentation(), _ file: StaticString = #file) async throws {
+    try generateHTML(with: indentation, to: outputPath)
+    try await generateCSS(with: indentation, to: outputPath)
   }
 
   /// Generates the HTML files of the site at the default `Output` directory of the package.
   /// - Parameter indentation: The indentation to use when rendering code in the HTML file.
-  private func generateHTML(with indentation: Indentation) throws {
+  func generateHTML(with indentation: Indentation, to path: URL) throws {
     let renderer = HTMLRenderer()
-    let htmlGenerator = Generator(content: renderer.render(homepage))
-    try htmlGenerator.write(file: "index", with: "html", to: outputPath)
+    let renderedContent = renderer.render(homepage)
+    let htmlGenerator = FileGenerator(content: renderedContent)
+    try htmlGenerator.write(file: "index", with: "html", to: path)
   }
 
   /// Generates the CSS files of the site at the default `Output` directory of the package.
   /// - Parameter indentation: The indentation to use when rendering code CSS file.
-  private func generateCSS(with indentation: Indentation) throws {
-    let renderer = StyleSheetRenderer()
-    let cssGenerator = Generator(content: renderer.render())
-    try cssGenerator.write(file: "styles", with: "css", to: outputPath)
+  func generateCSS(with indentation: Indentation, to path: URL) async throws {
+    let renderer = StyleSheetRenderer(indentation: indentation)
+    let renderedContent = await renderer.render()
+    let cssGenerator = FileGenerator(content: renderedContent)
+    try cssGenerator.write(file: "styles", with: "css", to: path)
   }
 }

--- a/Sources/SparkleCSS/Renderer/Renderer.swift
+++ b/Sources/SparkleCSS/Renderer/Renderer.swift
@@ -9,52 +9,36 @@ public struct StyleSheetRenderer {
   /// The indentation to apply to the document.
   let indentation: Indentation
 
-  /// The set of `@import` statements.
-  let imports: Set<Source>
-
-  /// The font faces to apply to the stylesheet.
-  let fontFaces: Set<Font.Face>
-
-  /// The set of rules that should be rendered.
-  let rules: Set<Rule>
+  /// The object that contains all the rules applied to the components.
+  private let rulesContainer = EnvironmentValues.rulesContainer
 
   // MARK: - Init
 
   /// Creates a new instance of `Render` by specifying a set of rules to render.
   /// - Parameters:
   ///   - indentation: The indentation to apply to the document.
-  ///   - fontFaces: The font faces to apply to the stylesheet.
-  ///   - rules: The set of rules that should be rendered.
-  public init(
-    indentation: Indentation = Indentation(),
-    imports: Set<Source> = [],
-    fontFaces: Set<Font.Face> = [],
-    rules: Set<Rule> = []
-  ) {
+  public init(indentation: Indentation = Indentation()) {
     self.indentation = indentation
-    self.imports = imports
-    self.fontFaces = fontFaces
-    self.rules = rules
   }
 
   // MARK: - Functions
 
   /// Renders the rules in `String` format, sorted alphabetically.
-  public func render() -> String {
-    let imports = imports
+  public func render() async -> String {
+    let imports = await rulesContainer.imports
       .map { source in
         ImportRenderer(indentation: indentation).render(source)
       }
       .sorted()
       .joined()
 
-    let fontFaces = fontFaces
+    let fontFaces = await rulesContainer.fontFaces
       .map { fontFace in
         FontFaceRenderer(indentation: indentation).render(fontFace)
       }
       .joined()
 
-    let rules = rules
+    let rules = await rulesContainer.rules
       .filter { rule in
         !rule.declarations.isEmpty
       }

--- a/Sources/SparkleCSS/Renderer/RulesContainer.swift
+++ b/Sources/SparkleCSS/Renderer/RulesContainer.swift
@@ -14,6 +14,8 @@ public actor RulesContainer {
   /// The set of rules that should be rendered.
   var rules: Set<Rule> = []
 
+  // MARK: - Init
+
   init(imports: Set<Source> = [], fontFaces: Set<Font.Face> = [], rules: Set<Rule> = []) {
     self.imports = imports
     self.fontFaces = fontFaces
@@ -50,6 +52,8 @@ public actor RulesContainer {
 public struct RulesContainerKey: EnvironmentKey {
   public static var defaultValue = RulesContainer()
 }
+
+// MARK: - EnvironmentValues
 
 extension EnvironmentValues {
   /// The instance of the `Renderer` in the environment.

--- a/Sources/SparkleTools/FileGenerator.swift
+++ b/Sources/SparkleTools/FileGenerator.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An object that generates a file from the given `String` content.
-public struct Generator {
+public struct FileGenerator {
 
   // MARK: - Stored Properties
 
@@ -32,6 +32,10 @@ public struct Generator {
 
     let newPath = path.appendingPathComponent(name).appendingPathExtension(pathExtension)
 
+    guard !content.isEmpty else {
+      throw Error.emptyContent
+    }
+
     guard let data = content.data(using: .utf8) else {
       throw Error.invalidData
     }
@@ -42,13 +46,29 @@ public struct Generator {
   }
 }
 
-extension Generator {
+extension FileGenerator {
   /// The possible errors that can occur when generating a file.
-  enum Error: Swift.Error {
+  enum Error: Swift.Error, LocalizedError {
     /// The `URL` does not link to a directory.
     case invalidFileURL
 
-    /// The data to write is invalid.
+    /// The data to write is not valid.
     case invalidData
+
+    /// The content is empty, so the file will not be written.
+    case emptyContent
+
+    var errorDescription: String? {
+      switch self {
+        case .invalidFileURL:
+          return "The URL does not link to a directory."
+
+        case .invalidData:
+          return "The data to write is not valid."
+
+        case .emptyContent:
+          return "The content is empty, so the file will not be written."
+      }
+    }
   }
 }

--- a/Tests/SparkleTests/SiteTests.swift
+++ b/Tests/SparkleTests/SiteTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SparkleHTML
+import SparkleTools
+@testable import Sparkle
+
+final class SiteTests: XCTestCase {
+
+  var testDirectory: URL!
+
+  override func setUpWithError() throws {
+    testDirectory = try FileManager.default.url(for: .developerDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+  }
+
+  func testCSSRendering() async throws {
+    let sut = ExampleSite()
+
+    sut.configureStyleSheet { container in
+      await container.import(.string("file.css"))
+      await container.insert(.backgroundColor(.color(.white)))
+    }
+
+    // The HTML needs to be generated in order for the style rules to be inserted in the `RulesContainer`.
+    try sut.generateHTML(with: Indentation(), to: testDirectory)
+    try await sut.generateCSS(with: Indentation(), to: testDirectory)
+
+    let resultPath = testDirectory.appendingPathComponent("styles").appendingPathExtension("css")
+
+    XCTAssertTrue(FileManager.default.fileExists(atPath: resultPath.path))
+  }
+}
+
+struct ExampleSite: Site {
+  var homepage: Page {
+    ExampleHome()
+  }
+}
+
+struct ExampleHome: Page {
+  public var head: Component {
+    Head {
+      Link(.rel(.stylesheet), .href("/styles.css"))
+    }
+  }
+
+  public var body: Component {
+    Body {
+      H1("Hello World")
+        .backgroundColor(.color(.white))
+    }
+    .backgroundColor(.color(.black))
+  }
+}

--- a/Tests/SparkleToolsTests/GeneratorTests.swift
+++ b/Tests/SparkleToolsTests/GeneratorTests.swift
@@ -14,7 +14,7 @@ final class GeneratorTests: XCTestCase {
   }
 
   func testRenderFile() throws {
-    let generator = Generator(content: "Hello World")
+    let generator = FileGenerator(content: "Hello World")
     try generator.write(file: "index", with: "html", to: testDirectory)
     XCTAssertTrue(FileManager.default.fileExists(atPath: testDirectory.path))
   }


### PR DESCRIPTION
## Improvements
- `Generator` has been renamed to `FileGenerator`.

## Fixes
- Resolved an issue where the renderer would render an empty stylesheet. This happened because the rules' handoff step was missing in the generation method.